### PR TITLE
Cost of using float point

### DIFF
--- a/demos/float/CMakeLists.txt
+++ b/demos/float/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.1...3.21)
+
+set(CMAKE_TOOLCHAIN_FILE
+    ${CMAKE_SOURCE_DIR}/../cmake/toolchain-arm-none-eabi.cmake)
+
+project(float VERSION 0.0.1 LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
+
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+    message(STATUS
+        "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+    file(DOWNLOAD
+        "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
+        "${CMAKE_BINARY_DIR}/conan.cmake"
+        EXPECTED_HASH SHA256=396e16d0f5eabdc6a14afddbcfff62a54a7ee75c6da23f32f7a31bc85db23484
+        TLS_VERIFY ON)
+endif()
+
+include(${CMAKE_BINARY_DIR}/conan.cmake)
+
+conan_cmake_run(REQUIRES liblpc40xx/0.0.1
+    BASIC_SETUP CMAKE_TARGETS
+    BUILD missing)
+
+set(EXECUTABLE ${PROJECT_NAME}.elf)
+
+add_executable(${EXECUTABLE} ${PROJECT_NAME}.cpp)
+
+target_include_directories(${EXECUTABLE} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>)
+target_compile_features(${EXECUTABLE} PRIVATE cxx_std_20)
+set_target_properties(${EXECUTABLE} PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_options(${EXECUTABLE} PRIVATE
+    -mcpu=cortex-m4 -mthumb -mfloat-abi=soft -mfpu=fpv4-sp-d16
+    -mtpcs-frame -mtpcs-leaf-frame)
+
+target_link_options(${EXECUTABLE} PRIVATE
+    -L${CMAKE_SOURCE_DIR}/../../linker/
+    -T${CMAKE_SOURCE_DIR}/../../linker/lpc4078.ld
+    -mcpu=cortex-m4 -mthumb -mfloat-abi=soft -mfpu=fpv4-sp-d16 -mtpcs-frame
+    -mtpcs-leaf-frame -Wl,-Map=${PROJECT_NAME}.map,--cref -Wl,--gc-sections
+    -Wl,--print-memory-usage)
+
+target_link_libraries(${EXECUTABLE} PRIVATE CONAN_PKG::liblpc40xx)
+
+# Print executable size
+add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+    COMMAND ${CMAKE_SIZE_UTIL} bin/${EXECUTABLE})
+
+# Create hex (intel hex) file
+add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -O ihex bin/${EXECUTABLE}
+    bin/${PROJECT_NAME}.hex)
+
+# Create bin (binary) file
+add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -O binary bin/${EXECUTABLE}
+    bin/${PROJECT_NAME}.bin)
+
+# Create disassembly file
+add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+    COMMAND ${CMAKE_OBJDUMP} --disassemble --demangle
+    bin/${EXECUTABLE} > bin/${PROJECT_NAME}.S)
+
+# Create disassembly file with source information
+add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+    COMMAND ${CMAKE_OBJDUMP} --all-headers --source
+    --disassemble --demangle bin/${EXECUTABLE}
+    > bin/${PROJECT_NAME}.lst)

--- a/demos/float/float.cpp
+++ b/demos/float/float.cpp
@@ -1,0 +1,55 @@
+#include <cstdint>
+
+constexpr bool use_float = true;
+constexpr bool use_double = true;
+constexpr bool convert_32_bit = true;
+constexpr bool convert_64_bit = true;
+
+volatile float a = 100.0f;
+volatile double b = 100.0;
+volatile bool result = false;
+volatile std::int32_t integer32 = 0;
+volatile std::int64_t integer64 = 0;
+
+int main()
+{
+  if constexpr (use_float) {
+    a = a + 1.0f;
+    a = a - 1.0f;
+    a = a * 2.0f;
+    a = a / 6.0f;
+
+    result = a < 1.0f;
+    result = a > 1.0f;
+    result = a == 1.0f;
+    result = a <= 1.0f;
+    result = a >= 1.0f;
+    result = a != 1.0f;
+  }
+
+  if constexpr (use_double) {
+    b = b + 1.0;
+    b = b - 1.0;
+    b = b * 2.0;
+    b = b / 6.0;
+
+    result = b < 1.0;
+    result = b > 1.0;
+    result = b == 1.0;
+    result = b <= 1.0;
+    result = b >= 1.0;
+    result = b != 1.0;
+  }
+
+  if constexpr (convert_32_bit) {
+    integer32 = static_cast<decltype(integer32)>(a);
+    integer64 = static_cast<decltype(integer64)>(a);
+  }
+
+  if constexpr (convert_64_bit) {
+    integer32 = static_cast<decltype(integer32)>(b);
+    integer64 = static_cast<decltype(integer64)>(b);
+  }
+
+  return 0;
+}

--- a/demos/float/libembeddedhal.tweaks.hpp
+++ b/demos/float/libembeddedhal.tweaks.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string_view>
+
+namespace embed::config {
+constexpr std::string_view platform = "lpc40xx";
+}  // namespace embed::config


### PR DESCRIPTION
Total cost without floats is 480 bytes. With all floats costs and
`-mfloat-abi=soft` total size of the binary is 5024 bytes. So the
cost of floats is 4544.